### PR TITLE
break change: Remove nonnull style method

### DIFF
--- a/packages/as-serde-json/assembly/serializer.ts
+++ b/packages/as-serde-json/assembly/serializer.ts
@@ -230,14 +230,6 @@ export class JSONSerializer extends Serializer<StringBuffer> {
     }
 
     @inline
-    serializeNonNullField<T>(
-        name: string | null,
-        value: nonnull<T>
-    ): StringBuffer {
-        return this.serializeField(name, value);
-    }
-
-    @inline
     serializeNullable<T>(t: T): StringBuffer {
         if (t == null) {
             this._buffer.write(NULL);

--- a/packages/as-serde-json/assembly/serializer.ts
+++ b/packages/as-serde-json/assembly/serializer.ts
@@ -198,9 +198,6 @@ export class JSONSerializer extends Serializer<StringBuffer> {
     serializeTupleElem<T>(value: T): StringBuffer {
         throw new Error("Method not implemented.");
     }
-    serializeNonNullTupleElem<T>(value: NonNullable<T>): StringBuffer {
-        throw new Error("Method not implemented.");
-    }
 
     @inline
     private _serializeField<T>(name: string, value: T): void {

--- a/packages/as-serde-scale/assembly/__tests__/serde.spec.ts
+++ b/packages/as-serde-scale/assembly/__tests__/serde.spec.ts
@@ -321,7 +321,7 @@ describe("ScaleSerializer", () => {
     it("Nulls", () => {
         let tests: Array<TestData<Nulls, StaticArray<u8>>> = [
             new TestData(new Nulls(), [0, 0, 0, 0, 0]),
-            new TestData(Nulls.test1(), [0, 0, 0, 0, 0x01, 0x04, 0x02]),
+            new TestData(Nulls.test1(), [0, 0, 0, 0x01, 0x00, 0x01, 0x04, 0x02]),
         ];
         for (let i = 0; i < tests.length; i++) {
             let test = tests[i];

--- a/packages/as-serde-scale/assembly/__tests__/testdata.ts
+++ b/packages/as-serde-scale/assembly/__tests__/testdata.ts
@@ -141,6 +141,7 @@ export class Nulls {
 
     static test1(): Nulls {
         let res = new Nulls();
+        res.n4 = new Map();
         res.n5 = [0x02];
         return res;
     }

--- a/packages/as-serde-scale/assembly/deserializer.ts
+++ b/packages/as-serde-scale/assembly/deserializer.ts
@@ -100,10 +100,6 @@ export class ScaleDeserializer extends Deserializer {
         return this.deserialize<T>();
     }
 
-    deserializeNonNullTupleElem<T>(): nonnull<T> {
-        return this.deserialize<nonnull<T>>();
-    }
-
     deserializeField<T>(_name: string | null): T {
         if (isNullable<T>()) {
             const b = this.deserializeBool();

--- a/packages/as-serde-scale/assembly/serializer.ts
+++ b/packages/as-serde-scale/assembly/serializer.ts
@@ -176,11 +176,6 @@ export class ScaleSerializer extends Serializer<BytesBuffer> {
         return this._buffer;
     }
 
-    serializeNonNullTupleElem<T>(value: NonNullable<T>): BytesBuffer {
-        this.serialize<NonNullable<T>>(value);
-        return this._buffer;
-    }
-
     @inline
     private _serializeField<T>(value: T): void {
         this.serialize<T>(value as T);
@@ -198,12 +193,6 @@ export class ScaleSerializer extends Serializer<BytesBuffer> {
 
     @inline
     serializeField<T>(name: string | null, value: T): BytesBuffer {
-        this._serializeField(value);
-        return this._buffer;
-    }
-
-    @inline
-    serializeNonNullField<T>(name: string | null, value: T): BytesBuffer {
         this._serializeField(value);
         return this._buffer;
     }

--- a/packages/as-serde/assembly/deserializer.ts
+++ b/packages/as-serde/assembly/deserializer.ts
@@ -1,6 +1,9 @@
 // @ts-nocheck
 import { IDeserialize } from "./index";
 
+/**
+ * All methods of `CoreDeserializer` will be used in as-serde-transfrom
+ */
 export abstract class CoreDeserializer {
     /**
      * startDeserializeField is called by a class `deserialize` method at the beginning.
@@ -26,26 +29,13 @@ export abstract class CoreDeserializer {
     abstract deserializeField<T>(name: string | null): T;
 
     /**
-     * deserializeNonNullField is called by a class `deserialize` method for non-null type.
-     * @param name field name
-     * @returns field value
-     */
-    abstract deserializeNonNullField<T>(name: string | null): nonnull<T>;
-
-    /**
-     * deserializeNonNullField is called by a class `deserialize` method at the end for nullable type.
+     * deserializeLastField is called by a class `deserialize` method at the end for nullable type.
      * @param name field name
      * @returns field value
      */
     abstract deserializeLastField<T>(name: string | null): T;
-    /**
-     * deserializeNonNullField is called by a class `deserialize` method at the end for non-null type.
-     * @param name field name
-     * @returns field value
-     */
-    abstract deserializeNonNullLastField<T>(name: string | null): nonnull<T>;
 
-    // TODO: maybe we can remove `deserializeLastField` and `deserializeNonNullLastField`
+    // TODO: maybe we can remove `deserializeLastField`
 }
 
 export abstract class Deserializer extends CoreDeserializer {
@@ -125,18 +115,9 @@ export abstract class Deserializer extends CoreDeserializer {
     abstract endDeserializeTuple(): void;
 
     abstract deserializeTupleElem<T>(): T;
-    abstract deserializeNonNullTupleElem<T>(): nonnull<T>;
-
-    deserializeNonNullField<T>(name: string | null): nonnull<T> {
-        return this.deserializeField<nonnull<T>>(name);
-    }
 
     deserializeLastField<T>(name: string | null): T {
         return this.deserializeField<T>(name);
-    }
-
-    deserializeNonNullLastField<T>(name: string | null): nonnull<T> {
-        return this.deserializeField<nonnull<T>>(name);
     }
 
     @inline

--- a/packages/as-serde/assembly/serializer.ts
+++ b/packages/as-serde/assembly/serializer.ts
@@ -22,27 +22,13 @@ export abstract class CoreSerializer<R> {
     abstract serializeField<T>(name: string | null, value: T): R;
 
     /**
-     * serializeNonNullField is called by a class `serialize` method for non-null type.
-     * @param name field name
-     * @param value field value
-     */
-    abstract serializeNonNullField<T>(name: string | null, value: nonnull<T>): R;
-
-    /**
      * serializeLastField is called by a class `serialize` method at the end for nullable type.
      * @param name field name
      * @param value field value
      */
     abstract serializeLastField<T>(name: string | null, value: T): R;
 
-    /**
-     * serializeNonNullLastField is called by a class `serialize` method at the end for non-null type.
-     * @param name field name
-     * @param value field value
-     */
-    abstract serializeNonNullLastField<T>(name: string | null, value: nonnull<T>): R;
-
-    // TODO: maybe we can remove `serializeLastField` and `serializeNonNullLastField`
+    // TODO: maybe we can remove `serializeLastField`
 }
 
 /**
@@ -88,16 +74,10 @@ export abstract class Serializer<R> extends CoreSerializer<R> {
     abstract startSerializeTuple(): R;
     abstract endSerializeTuple(): R;
     abstract serializeTupleElem<T>(value: T): R;
-    abstract serializeNonNullTupleElem<T>(value: nonnull<T>): R;
 
     @inline
     serializeLastField<T>(name: string | null, value: T): R {
         return this.serializeField<T>(name, value);
-    }
-
-    @inline
-    serializeNonNullLastField<T>(name: string | null, value: nonnull<T>): R {
-        return this.serializeNonNullField<T>(name, value);
     }
 
     /**

--- a/packages/as-serde/assembly/serializer.ts
+++ b/packages/as-serde/assembly/serializer.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import { ISerialize } from "as-serde";
 /**
- * All methods of CoreSerializer will be used in as-serde-transfrom
+ * All methods of` CoreSerializer` will be used in as-serde-transfrom
  */
 export abstract class CoreSerializer<R> {
     /**

--- a/packages/transform/src/consts.ts
+++ b/packages/transform/src/consts.ts
@@ -3,9 +3,7 @@ export const METHOD_SER = "serialize";
 export const METHOD_START_SER_FIELD = "startSerializeField";
 export const METHOD_END_SER_FIELD = "endSerializeField";
 export const METHOD_SER_FIELD = "serializeField";
-export const METHOD_SER_NONNULL_FIELD = "serializeNonNullField";
 export const METHOD_SER_LAST_FIELD = "serializeLastField";
-export const METHOD_SER_NONNULL_LAST_FIELD = "serializeNonNullLastField";
 export const METHOD_SER_ARG_NAME = "serializer";
 export const METHOD_SER_SIG = `serialize<__R, __S extends CoreSerializer<__R>>(serializer: __S): __R`;
 
@@ -14,9 +12,7 @@ export const METHOD_DES = "deserialize";
 export const METHOD_START_DES_FIELD = "startDeserializeField";
 export const METHOD_END_DES_FIELD = "endDeserializeField";
 export const METHOD_DES_FIELD = "deserializeField";
-export const METHOD_DES_NONNULL_FIELD = "deserializeNonNullField";
 export const METHOD_DES_LAST_FIELD = "deserializeLastField";
-export const METHOD_DES_NONNULL_LAST_FIELD = "deserializeNonNullLastField";
 export const METHOD_DES_ARG_NAME = "deserializer";
 export const METHOD_DES_SIG = `deserialize<__S extends CoreDeserializer>(deserializer: __S): this`;
 

--- a/packages/transform/src/tests/visitors/deserialize.spec.ts
+++ b/packages/transform/src/tests/visitors/deserialize.spec.ts
@@ -28,8 +28,8 @@ class Foo {
   b: bool = false;
   deserialize<__S extends CoreDeserializer>(deserializer: __S): this {
     deserializer.startDeserializeField();
-    this.s = deserializer.deserializeNonNullField<string>("s");
-    this.b = deserializer.deserializeNonNullLastField<bool>("b");
+    this.s = deserializer.deserializeField<string>("s");
+    this.b = deserializer.deserializeLastField<bool>("b");
     deserializer.endDeserializeField();
     return this;
   }
@@ -53,8 +53,8 @@ class Foo {
   b: bool = false;
   deserialize<__S extends CoreDeserializer>(deserializer: __S): this {
     deserializer.startDeserializeField();
-    this.s = deserializer.deserializeNonNullField<string>(null);
-    this.b = deserializer.deserializeNonNullLastField<bool>(null);
+    this.s = deserializer.deserializeField<string>(null);
+    this.b = deserializer.deserializeLastField<bool>(null);
     deserializer.endDeserializeField();
     return this;
   }
@@ -77,8 +77,8 @@ class Bar extends Foo {
   deserialize<__S extends CoreDeserializer>(deserializer: __S): this {
     deserializer.startDeserializeField();
     super.deserialize<__S>(deserializer);
-    this.s = deserializer.deserializeNonNullField<string>("s");
-    this.b = deserializer.deserializeNonNullLastField<bool>("b");
+    this.s = deserializer.deserializeField<string>("s");
+    this.b = deserializer.deserializeLastField<bool>("b");
     deserializer.endDeserializeField();
     return this;
   }
@@ -101,8 +101,8 @@ class Bar extends Foo {
   b: bool = false;
   deserialize<__S extends CoreDeserializer>(deserializer: __S): this {
     deserializer.startDeserializeField();
-    this.s = deserializer.deserializeNonNullField<string>("s");
-    this.b = deserializer.deserializeNonNullLastField<bool>("b");
+    this.s = deserializer.deserializeField<string>("s");
+    this.b = deserializer.deserializeLastField<bool>("b");
     deserializer.endDeserializeField();
     return this;
   }
@@ -165,8 +165,8 @@ class Bar extends Foo {
   b: bool = false;
   deserialize<__S extends CoreDeserializer>(deserializer: __S): this {
     deserializer.startDeserializeField();
-    this.s = deserializer.deserializeNonNullField<string>("s");
-    this.b = deserializer.deserializeNonNullLastField<bool>("b");
+    this.s = deserializer.deserializeField<string>("s");
+    this.b = deserializer.deserializeLastField<bool>("b");
     deserializer.endDeserializeField();
     return this;
   }

--- a/packages/transform/src/tests/visitors/serde.spec.ts
+++ b/packages/transform/src/tests/visitors/serde.spec.ts
@@ -31,14 +31,14 @@ class Foo {
   b: bool = false;
   serialize<__R, __S extends CoreSerializer<__R>>(serializer: __S): __R {
     serializer.startSerializeField();
-    serializer.serializeNonNullField<string>("s", this.s);
-    serializer.serializeNonNullLastField<bool>("b", this.b);
+    serializer.serializeField<string>("s", this.s);
+    serializer.serializeLastField<bool>("b", this.b);
     return serializer.endSerializeField();
   }
   deserialize<__S extends CoreDeserializer>(deserializer: __S): this {
     deserializer.startDeserializeField();
-    this.s = deserializer.deserializeNonNullField<string>("s");
-    this.b = deserializer.deserializeNonNullLastField<bool>("b");
+    this.s = deserializer.deserializeField<string>("s");
+    this.b = deserializer.deserializeLastField<bool>("b");
     deserializer.endDeserializeField();
     return this;
   }
@@ -65,14 +65,14 @@ class Foo {
   b: bool = false;
   serialize<__R, __S extends CoreSerializer<__R>>(serializer: __S): __R {
     serializer.startSerializeField();
-    serializer.serializeNonNullField<string>(null, this.s);
-    serializer.serializeNonNullLastField<bool>(null, this.b);
+    serializer.serializeField<string>(null, this.s);
+    serializer.serializeLastField<bool>(null, this.b);
     return serializer.endSerializeField();
   }
   deserialize<__S extends CoreDeserializer>(deserializer: __S): this {
     deserializer.startDeserializeField();
-    this.s = deserializer.deserializeNonNullField<string>(null);
-    this.b = deserializer.deserializeNonNullLastField<bool>(null);
+    this.s = deserializer.deserializeField<string>(null);
+    this.b = deserializer.deserializeLastField<bool>(null);
     deserializer.endDeserializeField();
     return this;
   }
@@ -95,15 +95,15 @@ class Bar extends Foo {
   serialize<__R, __S extends CoreSerializer<__R>>(serializer: __S): __R {
     serializer.startSerializeField();
     super.serialize<__R, __S>(serializer);
-    serializer.serializeNonNullField<string>("s", this.s);
-    serializer.serializeNonNullLastField<bool>("b", this.b);
+    serializer.serializeField<string>("s", this.s);
+    serializer.serializeLastField<bool>("b", this.b);
     return serializer.endSerializeField();
   }
   deserialize<__S extends CoreDeserializer>(deserializer: __S): this {
     deserializer.startDeserializeField();
     super.deserialize<__S>(deserializer);
-    this.s = deserializer.deserializeNonNullField<string>("s");
-    this.b = deserializer.deserializeNonNullLastField<bool>("b");
+    this.s = deserializer.deserializeField<string>("s");
+    this.b = deserializer.deserializeLastField<bool>("b");
     deserializer.endDeserializeField();
     return this;
   }
@@ -127,14 +127,14 @@ class Bar extends Foo {
   b: bool = false;
   serialize<__R, __S extends CoreSerializer<__R>>(serializer: __S): __R {
     serializer.startSerializeField();
-    serializer.serializeNonNullField<string>("s", this.s);
-    serializer.serializeNonNullLastField<bool>("b", this.b);
+    serializer.serializeField<string>("s", this.s);
+    serializer.serializeLastField<bool>("b", this.b);
     return serializer.endSerializeField();
   }
   deserialize<__S extends CoreDeserializer>(deserializer: __S): this {
     deserializer.startDeserializeField();
-    this.s = deserializer.deserializeNonNullField<string>("s");
-    this.b = deserializer.deserializeNonNullLastField<bool>("b");
+    this.s = deserializer.deserializeField<string>("s");
+    this.b = deserializer.deserializeLastField<bool>("b");
     deserializer.endDeserializeField();
     return this;
   }

--- a/packages/transform/src/tests/visitors/serialize.spec.ts
+++ b/packages/transform/src/tests/visitors/serialize.spec.ts
@@ -19,12 +19,12 @@ ${Case.Foo}
         const expected = `
 @serialize
 class Foo {
-  s: string | null = "test";
-  b: bool | null = false;
+  s: string = "test";
+  b: bool = false;
   serialize<__R, __S extends CoreSerializer<__R>>(serializer: __S): __R {
     serializer.startSerializeField();
-    serializer.serializeNonNullField<string>("s", this.s);
-    serializer.serializeNonNullLastField<bool>("b", this.b);
+    serializer.serializeField<string>("s", this.s);
+    serializer.serializeLastField<bool>("b", this.b);
     return serializer.endSerializeField();
   }
 }
@@ -46,8 +46,8 @@ class Foo {
   b: bool = false;
   serialize<__R, __S extends CoreSerializer<__R>>(serializer: __S): __R {
     serializer.startSerializeField();
-    serializer.serializeNonNullField<string>(null, this.s);
-    serializer.serializeNonNullLastField<bool>(null, this.b);
+    serializer.serializeField<string>(null, this.s);
+    serializer.serializeLastField<bool>(null, this.b);
     return serializer.endSerializeField();
   }
 }
@@ -68,8 +68,8 @@ class Bar extends Foo {
   serialize<__R, __S extends CoreSerializer<__R>>(serializer: __S): __R {
     serializer.startSerializeField();
     super.serialize<__R, __S>(serializer);
-    serializer.serializeNonNullField<string>("s", this.s);
-    serializer.serializeNonNullLastField<bool>("b", this.b);
+    serializer.serializeField<string>("s", this.s);
+    serializer.serializeLastField<bool>("b", this.b);
     return serializer.endSerializeField();
   }
 }
@@ -91,8 +91,8 @@ class Bar extends Foo {
   b: bool = false;
   serialize<__R, __S extends CoreSerializer<__R>>(serializer: __S): __R {
     serializer.startSerializeField();
-    serializer.serializeNonNullField<string>("s", this.s);
-    serializer.serializeNonNullLastField<bool>("b", this.b);
+    serializer.serializeField<string>("s", this.s);
+    serializer.serializeLastField<bool>("b", this.b);
     return serializer.endSerializeField();
   }
 }

--- a/packages/transform/src/tests/visitors/serialize.spec.ts
+++ b/packages/transform/src/tests/visitors/serialize.spec.ts
@@ -19,8 +19,8 @@ ${Case.Foo}
         const expected = `
 @serialize
 class Foo {
-  s: string = "test";
-  b: bool = false;
+  s: string | null = "test";
+  b: bool | null = false;
   serialize<__R, __S extends CoreSerializer<__R>>(serializer: __S): __R {
     serializer.startSerializeField();
     serializer.serializeNonNullField<string>("s", this.s);

--- a/packages/transform/src/utils.ts
+++ b/packages/transform/src/utils.ts
@@ -15,7 +15,6 @@ import { utils } from "visitor-as";
 
 export function getNameNullable(type: TypeNode): string {
     let ty = utils.getName(type);
-    console.log("Ty:", ty);
     if (type.isNullable && !ty.endsWith("null")) {
         ty = `${ty} | null`;
     }

--- a/packages/transform/src/utils.ts
+++ b/packages/transform/src/utils.ts
@@ -15,6 +15,7 @@ import { utils } from "visitor-as";
 
 export function getNameNullable(type: TypeNode): string {
     let ty = utils.getName(type);
+    console.log("Ty:", ty);
     if (type.isNullable && !ty.endsWith("null")) {
         ty = `${ty} | null`;
     }

--- a/packages/transform/src/visitors/deserialize.ts
+++ b/packages/transform/src/visitors/deserialize.ts
@@ -117,9 +117,9 @@ ${METHOD_DES_SIG} {
             return null;
         } else {
             const ty = getNameNullable(node.type);
-            return [`this.${name} = ${METHOD_DES_ARG_NAME}.${METHOD_DES_LAST_FIELD}<${ty}>(${nameStr});`].join(
-                "\n",
-            );
+            return [
+                `this.${name} = ${METHOD_DES_ARG_NAME}.${METHOD_DES_LAST_FIELD}<${ty}>(${nameStr});`,
+            ].join("\n");
         }
     }
 }

--- a/packages/transform/src/visitors/deserialize.ts
+++ b/packages/transform/src/visitors/deserialize.ts
@@ -13,8 +13,6 @@ import {
     METHOD_DES_ARG_NAME,
     METHOD_DES_FIELD,
     METHOD_DES_LAST_FIELD,
-    METHOD_DES_NONNULL_FIELD,
-    METHOD_DES_NONNULL_LAST_FIELD,
     METHOD_DES_SIG,
     METHOD_END_DES_FIELD,
     METHOD_START_DES_FIELD,
@@ -103,8 +101,7 @@ ${METHOD_DES_SIG} {
             return null;
         } else {
             const ty = getNameNullable(node.type);
-            const method = node.type.isNullable ? METHOD_DES_FIELD : METHOD_DES_NONNULL_FIELD;
-            return `this.${name} = ${METHOD_DES_ARG_NAME}.${method}<${ty}>(${nameStr});`;
+            return `this.${name} = ${METHOD_DES_ARG_NAME}.${METHOD_DES_FIELD}<${ty}>(${nameStr});`;
         }
     }
 
@@ -120,10 +117,7 @@ ${METHOD_DES_SIG} {
             return null;
         } else {
             const ty = getNameNullable(node.type);
-            const method = node.type.isNullable
-                ? METHOD_DES_LAST_FIELD
-                : METHOD_DES_NONNULL_LAST_FIELD;
-            return [`this.${name} = ${METHOD_DES_ARG_NAME}.${method}<${ty}>(${nameStr});`].join(
+            return [`this.${name} = ${METHOD_DES_ARG_NAME}.${METHOD_DES_LAST_FIELD}<${ty}>(${nameStr});`].join(
                 "\n",
             );
         }

--- a/packages/transform/src/visitors/serialize.ts
+++ b/packages/transform/src/visitors/serialize.ts
@@ -14,8 +14,6 @@ import {
     METHOD_SER_ARG_NAME,
     METHOD_SER_FIELD,
     METHOD_SER_LAST_FIELD,
-    METHOD_SER_NONNULL_FIELD,
-    METHOD_SER_NONNULL_LAST_FIELD,
     METHOD_SER_SIG,
     METHOD_START_SER_FIELD,
 } from "../consts.js";
@@ -108,8 +106,7 @@ ${METHOD_SER_SIG} {
             return null;
         } else {
             const ty = getNameNullable(node.type);
-            const method = node.type.isNullable ? METHOD_SER_FIELD : METHOD_SER_NONNULL_FIELD;
-            return `${METHOD_SER_ARG_NAME}.${method}<${ty}>(${nameStr}, this.${name});`;
+            return `${METHOD_SER_ARG_NAME}.${METHOD_SER_FIELD}<${ty}>(${nameStr}, this.${name});`;
         }
     }
 
@@ -125,10 +122,7 @@ ${METHOD_SER_SIG} {
             return null;
         } else {
             const ty = getNameNullable(node.type);
-            const method = node.type.isNullable
-                ? METHOD_SER_LAST_FIELD
-                : METHOD_SER_NONNULL_LAST_FIELD;
-            return `${METHOD_SER_ARG_NAME}.${method}<${ty}>(${nameStr}, this.${name});`;
+            return `${METHOD_SER_ARG_NAME}.${METHOD_SER_LAST_FIELD}<${ty}>(${nameStr}, this.${name});`;
         }
     }
 }


### PR DESCRIPTION
We could not detect the nullable of all types at `afterParse stage`, so this should be implmented by the concrete serde lib to handle the nullable/nonull type.

At current stage, If user use decorator to `extends` serde class, it will not break anything.